### PR TITLE
[framework] add standardized issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,31 @@
+---
+name: Bug Report
+about: 不具合の報告と再現手順を共有するテンプレート
+title: "[bug] "
+labels: "bug,status::triage,impact::medium"
+assignees: ""
+---
+
+## 概要 / Summary
+- 発生した事象を一言で記載してください。
+
+## 環境 / Environment
+- 確認した環境（branch / worktree / コマンド 等）を記載してください。
+
+## 再現手順 / Steps to Reproduce
+1. 
+2. 
+3. 
+
+## 期待結果 / Expected Behavior
+- 正常時に期待される振る舞いを記載してください。
+
+## 実際の結果 / Actual Behavior
+- 実際に観測された結果を記載してください。ログ等があれば貼付してください。
+
+## 受け入れ基準 / Acceptance Criteria
+- [ ] 問題の再現が停止する、または説明可能な回避策が提示される。
+- [ ] 必要なテストや監視の更新が行われる。
+
+## 次のアクション / Next Actions
+- [ ] 担当者・期限・フォローアップを記載してください。

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation Hub
+    url: https://github.com/w-pinkietech/YokaKit_Studio/tree/main/docs
+    about: ドキュメントやガイドラインを確認してください。

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,25 @@
+---
+name: Feature Request
+about: Code Output やユーザー価値に直結する新機能の提案
+title: "[feature] "
+labels: "track::delivery,status::triage,impact::medium"
+assignees: ""
+---
+
+## 背景 / Context
+- どの Intent / Unit / User Story に関連するか、関連資料へのリンクを示してください。
+
+## ユーザー価値 / User Value
+- 利用者が得るメリットや改善される体験を記載してください。
+
+## 要件 / Requirements
+- 機能要件・非機能要件を箇条書きで整理してください。
+
+## 受け入れ基準 / Acceptance Criteria
+- [ ] 完了判定に必要な条件をチェックリストで記載してください。
+
+## 依存関係 / Dependencies
+- ブロッカーや他 Issue / PR との依存があれば記載してください。
+
+## 次のアクション / Next Actions
+- [ ] 作業オーナー / Due 日付 を明記してください。

--- a/.github/ISSUE_TEMPLATE/framework_task.md
+++ b/.github/ISSUE_TEMPLATE/framework_task.md
@@ -1,0 +1,25 @@
+---
+name: Framework Task
+about: Context Studio のガバナンス / プロセス整備タスク用テンプレート
+title: "[framework] "
+labels: "track::framework,artifact::process,status::triage"
+assignees: ""
+---
+
+## 背景 / Context
+- どの文書・運用・状況が対象か、端的に記載してください。
+
+## 課題 / Problem
+- 現状の問題点、リスク、影響範囲を整理してください。
+
+## 提案 / Proposal
+- 解決策や検討したい選択肢を箇条書きで記載してください。
+
+## 影響 / Impact
+- 期待される効果、影響範囲、関係者を記載してください。
+
+## 受け入れ基準 / Acceptance Criteria
+- [ ] 想定する完了状態をチェックリストで列挙してください。
+
+## 次のアクション / Next Actions
+- [ ] 作業オーナー / Due 日付 を明記してください。

--- a/PR_DRAFT.md
+++ b/PR_DRAFT.md
@@ -1,35 +1,27 @@
-# [framework] status:: ラベル運用の簡素化
+# [framework] add standardized issue templates
 
 ## 概要
-- `status::` 軸のラベルを `triage` / `ready` / `in-progress` / `in-review` / `done` / `blocked` に再編成し、作業ステータスを明瞭化。
-- 運用ルールを `docs/10-governance/framework/README.md` および関連ガイドに反映。
-- `scripts/setup_labels.sh` の同期対象を更新し、Dry-run / 本番同期を実施。
-- Exec Plan 着手時に Issue を自動検出/作成する `scripts/exec_plan/bootstrap.sh` を追加。
-- 既存 Issue (#1) のステータスラベルを新体系に合わせて更新し、旧 `status::needs-decision` を削除。
+- `.github/ISSUE_TEMPLATE/` に `framework_task`, `feature_request`, `bug_report` の3種類のテンプレートを追加し、背景/課題/提案/影響/受け入れ基準/次のアクションを共通化。
+- ブランチ運用ガイド（`docs/10-governance/framework/README.md`）とエージェント向けチェックリストを更新し、テンプレート活用と受け入れ基準の明記を反映。
+- `docs/20-process/agents/README.md` にテンプレート利用ルールを追加し、AI エージェントが必ず統一フォーマットで起票するよう整備。
 
 ## 影響範囲
-- ガバナンスドキュメント（`docs/10-governance/framework/README.md`）
-- エージェントガイド（`docs/20-process/agents/README.md`）
-- ドキュメント SOP（`docs/00-foundation/documentation/standard-procedures.md`）
-- ラベル同期スクリプト（`scripts/setup_labels.sh`）
-- Exec Plan ブートストラップ（`scripts/exec_plan/bootstrap.sh`）
-- Exec Plan（`records/by-pr/22-status-label-flow/plans.md`）
+- `.github/ISSUE_TEMPLATE/*.md`, `.github/ISSUE_TEMPLATE/config.yml`
+- `docs/10-governance/framework/README.md`
+- `docs/20-process/agents/AGENTS.md`
+- `docs/20-process/agents/README.md`
 
 ## 検証
 ```bash
-# ラベル定義のDry-run検証
-GITHUB_TOKEN=dummy ./scripts/setup_labels.sh example/example --dry-run
-
-# 本番リポジトリへのラベル同期
-GITHUB_TOKEN=$(gh auth token) scripts/setup_labels.sh w-pinkietech/YokaKit_Studio
-
-# Issue #1 のステータスラベル更新
-gh issue edit 1 --remove-label "status::needs-decision" --add-label "status::triage"
-
-# Exec Plan ブートストラップ（Dry-run）
-scripts/exec_plan/bootstrap.sh --slug <slug> --filter-label track::framework --title "[framework] <title>" --dry-run
+# スモークテスト: テンプレート本文を用いた Issue 起票と即時クローズ
+body=$(tail -n +8 .github/ISSUE_TEMPLATE/framework_task.md)
+issue_url=$(gh issue create --title "[framework] Template smoke test" --body "$body" \
+  --label track::framework --label artifact::process --label status::triage --label impact::low)
+issue_number=${issue_url##*/}
+gh issue close "$issue_number" --comment "Smoke-test for new issue templates. Verified layout; closing immediately."
 ```
 
 ## 参考
-- Exec Plan: `records/by-pr/22-status-label-flow/plans.md`
-- Records summary: `records/by-pr/22-status-label-flow/summary.md`
+- Exec Plan: `records/by-pr/31-issue-templates/plans.md`
+- Records summary: `records/by-pr/31-issue-templates/summary.md`
+- Issue: #29

--- a/docs/10-governance/framework/README.md
+++ b/docs/10-governance/framework/README.md
@@ -45,6 +45,13 @@ track::framework + artifact::documentation + status::in-progress + impact::mediu
 
 ## Issue テンプレート（推奨構成）
 
+GitHub では `.github/ISSUE_TEMPLATE/` 配下に以下のテンプレートを用意している。AI エージェントを含め全員が同一フォーマットで起票すること。
+- `framework_task.md`（ガバナンス・プロセス整備用）
+- `feature_request.md`（利用者価値を高める機能提案）
+- `bug_report.md`（不具合報告）
+
+いずれのテンプレートも下記の骨子を共有する。
+
 ```
 ## 背景 / Context
 - 何が起きているか、どのドキュメント/箇所が対象か
@@ -57,6 +64,9 @@ track::framework + artifact::documentation + status::in-progress + impact::mediu
 
 ## 影響 / Impact
 - 波及範囲、想定されるメリット/デメリット
+
+## 受け入れ基準 / Acceptance Criteria
+- 完了判定に必要な条件をチェックリストで記載
 
 ## 次のアクション / Next Actions
 - 決定が必要なこと、作業オーナー、期限の目安

--- a/docs/20-process/agents/AGENTS.md
+++ b/docs/20-process/agents/AGENTS.md
@@ -6,6 +6,7 @@
 
 ## 事前確認
 - [ ] 対応する Issue に `track::`, `artifact::`, `status::`, `impact::` ラベルが付与されているか。
+- [ ] Issue 起票時は `.github/ISSUE_TEMPLATE/` のテンプレート（framework / feature / bug）を利用したか。
 - [ ] 作業ブランチが `framework/<issue-number>-<slug>` 等の命名規則に従っているか。
 - [ ] `.aidlc/contexts/<id>/` で関連する Intent / Domain Design / ADR を確認したか。
 - [ ] `gh auth status` を実行し、GitHub CLI の認証が有効か確認したか。

--- a/docs/20-process/agents/README.md
+++ b/docs/20-process/agents/README.md
@@ -29,6 +29,7 @@ AIエージェントが YokaKit Studio のコンテキストを効率的に参�
 ## Workflow Agreements
 - **ブランチ命名:** フレームワーク関連は `framework/<issue-number>-<slug>`、機能開発は `feature/<slug>` を原則とする。
 - **Issue ファースト:** すべての変更はIssueを起点とし、`status::triage`→`status::ready`→`status::in-progress`→`status::in-review`→`status::done` の遷移を意識して進める。
+- **テンプレート活用:** Issue を起票する際は `.github/ISSUE_TEMPLATE/` のテンプレート（framework_task / feature_request / bug_report）を用いる。
 - **PR必須:** `10-governance/framework/README.md` に記載されたレビューフローを遵守し、Draft PR でも議論を開始する。
 
 ## AI-DLC Execution

--- a/records/by-pr/31-issue-templates/plans.md
+++ b/records/by-pr/31-issue-templates/plans.md
@@ -1,0 +1,99 @@
+# Exec Plan Snapshot (2025-01-13 04:45:20)
+
+> branch: framework/29-issue-templates  commit: cd0f7fc
+
+---
+# Exec Plan: Issue テンプレート整備
+
+> 使い方（雛形：Deferred GitHub Ops 推奨）
+> - このファイルをブランチ直下 `plans.md` にコピーして編集します。
+> - プラン初稿に合意したら、Issue/PR（Draft）を作成し `scripts/records/new_pr_summary.sh` で要約を生成、マージ前に `scripts/records/archive_plan.sh` でスナップショットを保存します。
+>
+> 推奨コマンド例:
+> ```bash
+> set -euo pipefail
+> ISSUE=<n>; SLUG=<slug>; PR=<pr>; REPO=https://github.com/<org>/<repo>; AUTHOR=@you
+> scripts/exec_plan/bootstrap.sh --slug ${SLUG} --filter-label track::framework \
+>   --title "[framework] <title>" --labels "track::framework,artifact::<type>,status::triage,lifecycle::draft" \
+>   --repo ${REPO}
+> cp docs/60-templates/exec-plan.md plans.md
+> bash scripts/records/new_pr_summary.sh ${PR} ${SLUG} --issue ${ISSUE} --repo-url ${REPO} --author ${AUTHOR}
+> # 作業…
+> bash scripts/records/archive_plan.sh ${PR} ${SLUG}
+> rm plans.md
+> ```
+
+## 目的 / ゴール
+- `.github/ISSUE_TEMPLATE/` に Context Studio 向けの Issue テンプレートを追加し、起票フローを標準化する。
+- README / docs に記載されたテンプレート要件と整合を取り、AI エージェントが利用しやすい形にする。
+- PR 差分はテンプレート追加とドキュメント整備のみに留め、テスト・検証結果を記録する。
+
+## 範囲 / 非範囲
+- 対象: `.github/ISSUE_TEMPLATE/` ディレクトリ新設、Issue テンプレート Markdown 作成、README/doc 更新（必要時）、PR テンプレートとの整合確認。
+- 非範囲: GitHub の Issue フォーム（YAML）導入、既存 PR テンプレートの全面改修、他リポジトリへの横展開。
+- 前提: docs で定義済みの Issue 項目（背景 / 課題 / 提案 / 影響 / 次のアクション）に準拠する。
+
+## 参照 / コンテキスト
+- Issue: #29（`scripts/exec_plan/bootstrap.sh --slug issue-templates --filter-label track::framework`）
+- ADR / 設計: （該当なし）
+- 関連Docs: `docs/20-process/agents/AGENTS.md`, `docs/20-process/exec-plan.md`, `docs/00-foundation/documentation/standard-procedures.md`
+- PR: https://github.com/w-pinkietech/YokaKit_Studio/pull/31
+- Records: `records/by-pr/31-issue-templates/summary.md`
+
+## 全体像
+- 現状 Issue 起票時の雛形が存在せず、背景や課題、提案など必要項目が人によりばらついている。
+- Context Studio に合わせたテンプレート（例: framework task / bug report / feature request）を追加し、AI も利用できるよう YAML front matter を整備する。
+- README / docs にテンプレート利用方法を明記し、Exec Plan や records と矛盾しないよう確認する。
+
+## 進捗状況（Checklist）
+- [x] スパイク / 調査
+- [x] 実装（コア）
+- [x] テスト追加 / 検証
+- [x] ドキュメント更新 / リンク確認
+- [x] Plan スナップショット保存（`archive_plan.sh` 実行）
+
+## 実行計画（Plan）
+1. 既存ドキュメントを確認し、Issue に要求される必須項目と分類を整理する（framework task / feature / bug など）。
+2. `.github/ISSUE_TEMPLATE/` ディレクトリを新設し、テンプレート Markdown（YAML フロントマター）を作成する。
+3. README などでテンプレートへの導線が必要か確認し、必要時に追記・修正する。
+4. PR 作成前にテンプレート動作（`gh issue create --template` 等）を Dry-run で確認する。
+5. records（summary / plans スナップショット）を更新し、Plan 後片付けを行う。
+
+## 決定ログ（Decision Log）
+- 2025-01-13: Issue テンプレートは Markdown + YAML front matter で実装し、AI エージェントも利用可能な構造にする方針。
+
+## 発見と驚き（Findings）
+- GitHub Markdown テンプレートは YAML フロントマター内 `labels` をカンマ区切りで指定する必要があるため、カスタムラベルを正確に記載した。
+- テンプレートに `受け入れ基準` ブロックを追加することで Issue の完了定義が揃うことを再確認。
+- `gh issue create` でテンプレート本文を流用したスモークテスト（Issue #30）を実施し、想定どおりのレイアウトになることを確認、即時クローズ。
+
+## リスク / 代替案
+- リスク: テンプレートが冗長になり利用を避けられる / 回避策: 必須項目は最小構成にし、補足セクションは任意で記載。
+- 代替案: GitHub Issue フォーム（YAML）での実装 → 設定が複雑になり、当面の必要性が低いため採用しない。
+
+## 受け入れ基準 / Acceptance Criteria
+- Issue テンプレートが `.github/ISSUE_TEMPLATE/` に追加され、`gh issue create --template` 等で利用可能。
+- テンプレートには背景 / 課題 / 提案 / 影響 / 次のアクションを含む枠組みが用意されている。
+- README / docs にテンプレート利用方法と導線が整備されている（必要時）。
+- PR ではテンプレート追加とドキュメント更新、動作確認結果が記録されている。
+
+## To-Do
+1. [x] `.github/ISSUE_TEMPLATE/` に framework / feature / bug テンプレートを追加
+2. [x] ガバナンス & エージェントドキュメントをテンプレート運用に合わせて更新
+3. [x] `gh issue create` を用いたスモークテスト（Issue #30）でレイアウト確認
+4. [x] records に plans.md を保存（`bash scripts/records/archive_plan.sh <pr-number> <slug>` を実行し、`records/by-pr/<pr>-<slug>/plans.md` と `summary.md` のリンクを確認）
+5. [x] records/by-pr/<pr>-<slug>/summary.md に作業内容を記述（Summary / Key Points / Decisions / Links を反映）
+6. [x] records への保存後、ブランチ上の `plans.md` を削除（PR 差分から除外）
+
+## Cross-Repository（必要時）
+| Repo | Branch | Order | Notes |
+|------|--------|-------|-------|
+| <name> | <framework/<issue>-<slug>> | <1/2/…> | 依存やゲートのメモ |
+
+## 次アクション
+- [x] Draft PR を作成し、records スナップショットを更新する。
+
+---
+メモ
+- 本ファイルは作業ブランチ（短命文書）。`archive_plan.sh` で保存した後はブランチから削除し、PR（records/by-pr）から参照可能にする。
+- records の要約には本ファイル（plans.md）へのリンクを追加する。

--- a/records/by-pr/31-issue-templates/summary.md
+++ b/records/by-pr/31-issue-templates/summary.md
@@ -1,0 +1,42 @@
+---
+id: pr-31-issue-templates
+type: pr # 原則 pr を使用（issue/commit は例外時のみ）
+status: open
+relates_to:
+  issues: ["#29"]
+  prs: []            # 任意（関連PRがあれば）
+  commits: []        # 任意（PRを通さないHotfix時など）
+authors: ["@codex-agent"]
+dates:
+  created: 2025-01-13
+  updated: 2025-01-13
+links:
+  thread: https://github.com/w-pinkietech/YokaKit_Studio/pull/31
+  permalinks:
+    - .github/ISSUE_TEMPLATE/framework_task.md
+    - .github/ISSUE_TEMPLATE/feature_request.md
+    - .github/ISSUE_TEMPLATE/bug_report.md
+    - docs/10-governance/framework/README.md
+    - docs/20-process/agents/AGENTS.md
+    - docs/20-process/agents/README.md
+repos: []
+decisions:
+  - summary: "Issue 起票を標準化するため、framework / feature / bug のテンプレートを追加し、関連ドキュメントへ導線を整備する。"
+    impacts: [.github/ISSUE_TEMPLATE/framework_task.md, .github/ISSUE_TEMPLATE/feature_request.md, .github/ISSUE_TEMPLATE/bug_report.md, docs/10-governance/framework/README.md, docs/20-process/agents/AGENTS.md, docs/20-process/agents/README.md]
+next_actions: []
+---
+
+## Summary
+framework / feature / bug の 3 種類の Issue テンプレートを追加し、背景・課題・提案・影響・受け入れ基準・次のアクションを共通化した。  
+ガバナンス文書とエージェント向けチェックリストを更新し、テンプレート利用をルール化。  
+`gh issue create` を用いたスモークテスト（#30）でテンプレートのレイアウトを確認済み。
+
+## Key Points
+- `.github/ISSUE_TEMPLATE/` に framework_task / feature_request / bug_report を追加。
+- `docs/10-governance/framework/README.md` にテンプレートの参照方法と受け入れ基準を追記。
+- `docs/20-process/agents/AGENTS.md` / `docs/20-process/agents/README.md` にテンプレート利用チェックを追加。
+- Issue #30 を使ってスモークテストを実施し、その場でクローズ。
+
+## Links
+- Plan Snapshot: records/by-pr/31-issue-templates/plans.md
+- Smoke Test: https://github.com/w-pinkietech/YokaKit_Studio/issues/30


### PR DESCRIPTION
# [framework] add standardized issue templates

## 概要
- `.github/ISSUE_TEMPLATE/` に `framework_task`, `feature_request`, `bug_report` の3種類のテンプレートを追加し、背景/課題/提案/影響/受け入れ基準/次のアクションを共通化。
- ブランチ運用ガイド（`docs/10-governance/framework/README.md`）とエージェント向けチェックリストを更新し、テンプレート活用と受け入れ基準の明記を反映。
- `docs/20-process/agents/README.md` にテンプレート利用ルールを追加し、AI エージェントが必ず統一フォーマットで起票するよう整備。

## 影響範囲
- `.github/ISSUE_TEMPLATE/*.md`, `.github/ISSUE_TEMPLATE/config.yml`
- `docs/10-governance/framework/README.md`
- `docs/20-process/agents/AGENTS.md`
- `docs/20-process/agents/README.md`

## 検証
```bash
# スモークテスト: テンプレート本文を用いた Issue 起票と即時クローズ
body=$(tail -n +8 .github/ISSUE_TEMPLATE/framework_task.md)
issue_url=$(gh issue create --title "[framework] Template smoke test" --body "$body" \
  --label track::framework --label artifact::process --label status::triage --label impact::low)
issue_number=${issue_url##*/}
gh issue close "$issue_number" --comment "Smoke-test for new issue templates. Verified layout; closing immediately."
```

## 参考
- Exec Plan: `plans.md`（records スナップショットは PR 前に更新）
- Issue: #29
